### PR TITLE
remove extra dot after version

### DIFF
--- a/cursor-appimage/PKGBUILD
+++ b/cursor-appimage/PKGBUILD
@@ -13,7 +13,7 @@ options=('!strip')
 depends=('hicolor-icon-theme' 'zlib')
 
 # Use curl to get the filename and extract the version
-# pkgver=$(curl -s -o /dev/null -D - -r 0-0 https://download.cursor.sh/linux/appImage/x64 | grep -o -E 'filename=.*$' | sed -e 's/.*cursor-\(.*\)\(.*\)\.AppImage.*/\1\.\2/')
+# pkgver=$(curl -s -o /dev/null -D - -r 0-0 https://download.cursor.sh/linux/appImage/x64 | grep -o -E 'filename=.*$' | sed -e 's/.*cursor-\(.*\)\.AppImage.*/\1/')
 
 source=("${_pkgname}-${pkgver}.AppImage::https://download.cursor.sh/linux/appImage/x64")
 sha256sums=('c172265ff5a7db6660cf44680785e1de87ed1b8cfdb127c8b615130ed8856ba2')


### PR DESCRIPTION
I apologize. I messed up on the last commit since the filename removed -build- yesterday.

from `paru -Qi` (after uncommenting)
Before:
```
Version         : 0.20.2.-1
```
Now:
```
Version         : 0.20.2-1

```

Thank you!!!